### PR TITLE
Add board prop support to exported board components

### DIFF
--- a/lib/ArduinoShield/ArduinoShield.circuit.tsx
+++ b/lib/ArduinoShield/ArduinoShield.circuit.tsx
@@ -1,7 +1,16 @@
-import type { ChipProps } from "@tscircuit/props"
+import type { BoardProps, ChipProps } from "@tscircuit/props"
 import { ArduinoShieldFootprint } from "./ArduinoShieldFootprint"
 
-export const ArduinoShield = (props: ChipProps & { children?: any }) => (
+interface ArduinoShieldProps extends ChipProps {
+  children?: any
+  boardProps?: BoardProps
+}
+
+export const ArduinoShield = ({
+  children,
+  boardProps,
+  ...chipProps
+}: ArduinoShieldProps) => (
   <board
     outline={[
       { x: -34.29, y: 26.67 }, // top-left corner
@@ -14,10 +23,12 @@ export const ArduinoShield = (props: ChipProps & { children?: any }) => (
       { x: 34.29, y: -26.67 }, // bottom-right corner
       { x: -34.29, y: -26.67 }, // bottom-left corner
     ]}
+    {...boardProps}
   >
     <group>
       <chip
-        name={props.name}
+        {...chipProps}
+        name={chipProps.name}
         pinLabels={{
           pin1: "A0",
           pin2: "A1",
@@ -106,7 +117,7 @@ export const ArduinoShield = (props: ChipProps & { children?: any }) => (
         }}
         footprint={<ArduinoShieldFootprint />}
       />
-      {props.children}
+      {children}
     </group>
   </board>
 )

--- a/lib/MicroModBoard/MicroModBoard.tsx
+++ b/lib/MicroModBoard/MicroModBoard.tsx
@@ -1,11 +1,19 @@
-import type { ChipProps } from "@tscircuit/props"
+import type { BoardProps, ChipProps } from "@tscircuit/props"
 import { MicroModBoardFootprint } from "./MicroModBoardFootprint"
 import { processorOutline, functionOutline } from "./outlines/boardOutlines"
 
+interface MicroModBoardProps extends ChipProps {
+  children?: any
+  variant?: "processor" | "function"
+  boardProps?: BoardProps
+}
+
 export const MicroModBoard = ({
   variant = "processor",
-  ...props
-}: ChipProps & { children?: any; variant?: "processor" | "function" }) => {
+  boardProps,
+  children,
+  ...chipProps
+}: MicroModBoardProps) => {
   let outline
   const pinLabels = {
     pin2: ["V3_3_1"],
@@ -82,10 +90,11 @@ export const MicroModBoard = ({
   outline = variant === "processor" ? processorOutline : functionOutline
 
   return (
-    <board outline={outline}>
+    <board outline={outline} {...boardProps}>
       <group>
         <chip
-          name={props.name}
+          {...chipProps}
+          name={chipProps.name}
           footprint={<MicroModBoardFootprint variant={variant} />}
           schWidth={2.8}
           pinLabels={pinLabels}
@@ -216,7 +225,7 @@ export const MicroModBoard = ({
             },
           }}
         />
-        {props.children}
+        {children}
       </group>
     </board>
   )

--- a/lib/RaspberryPiHatBoard/RaspberryPiHatBoard.circuit.tsx
+++ b/lib/RaspberryPiHatBoard/RaspberryPiHatBoard.circuit.tsx
@@ -1,7 +1,16 @@
-import type { ChipProps } from "@tscircuit/props"
+import type { BoardProps, ChipProps } from "@tscircuit/props"
 import { OutlineBuilder } from "../../util/outlineBuilder"
 
-export const RaspberryPiHatBoard = (props: ChipProps & { children?: any }) => {
+interface RaspberryPiHatBoardProps extends ChipProps {
+  children?: any
+  boardProps?: BoardProps
+}
+
+export const RaspberryPiHatBoard = ({
+  children,
+  boardProps,
+  ...chipProps
+}: RaspberryPiHatBoardProps) => {
   const outline = new OutlineBuilder(0, 28)
     .lineTo(32.5, 28)
     .corner({ radius: 1, turn: "ccw" })
@@ -71,9 +80,10 @@ export const RaspberryPiHatBoard = (props: ChipProps & { children?: any }) => {
   }
 
   return (
-    <board outline={outline}>
+    <board outline={outline} {...boardProps}>
       <group>
         <chip
+          {...chipProps}
           name="JP1"
           schWidth={3.5}
           pinLabels={pinLabels}
@@ -167,7 +177,7 @@ export const RaspberryPiHatBoard = (props: ChipProps & { children?: any }) => {
         <hole diameter={2.8} pcbX={29} pcbY={-24.5} />
         <hole diameter={2.8} pcbX={-29} pcbY={-24.5} />
         <hole diameter={2.8} pcbX={29} pcbY={24.5} />
-        {props.children}
+        {children}
       </group>
     </board>
   )

--- a/lib/XiaoBoard/XiaoBoard.circuit.tsx
+++ b/lib/XiaoBoard/XiaoBoard.circuit.tsx
@@ -1,4 +1,4 @@
-import type { ChipProps } from "@tscircuit/props"
+import type { BoardProps, ChipProps } from "@tscircuit/props"
 import { XiaoBoardFootprint } from "./XiaoBoardFootprint"
 import { outlineBuilder } from "../../util/outlineBuilder"
 
@@ -6,12 +6,15 @@ interface XiaoBoardProps extends ChipProps {
   children?: any
   variant?: "RP2040" | "Receiver"
   withPlatedHoles?: boolean
+  boardProps?: BoardProps
 }
 
 export const XiaoBoard = ({
   variant,
   withPlatedHoles = false,
-  ...props
+  boardProps,
+  children,
+  ...chipProps
 }: XiaoBoardProps) => {
   const DefaultPinLabels = {
     pin1: "A0",
@@ -98,10 +101,11 @@ export const XiaoBoard = ({
     .toArray()
 
   return (
-    <board outline={outline}>
+    <board outline={outline} {...boardProps}>
       <group>
         <chip
-          name={props.name}
+          {...chipProps}
+          name={chipProps.name}
           footprint={
             <XiaoBoardFootprint
               variant={variant}
@@ -133,7 +137,7 @@ export const XiaoBoard = ({
             },
           })}
         />
-        {props.children}
+        {children}
       </group>
     </board>
   )

--- a/tests/test.test.tsx
+++ b/tests/test.test.tsx
@@ -1,11 +1,44 @@
-import { test, expect } from "bun:test"
+import { expect, test } from "bun:test"
 import { ArduinoShield } from "../lib/ArduinoShield/ArduinoShield.circuit"
 import { RaspberryPiHatBoard } from "../lib/RaspberryPiHatBoard/RaspberryPiHatBoard.circuit"
 import { MicroModBoard } from "../lib/MicroModBoard/MicroModBoard"
 import { XiaoBoard } from "../lib/XiaoBoard/XiaoBoard.circuit"
-test("test", () => {
+
+test("exports exist", () => {
   expect(ArduinoShield).toBeDefined()
   expect(RaspberryPiHatBoard).toBeDefined()
   expect(MicroModBoard).toBeDefined()
-  expect(XiaoBoard).toBeDefined() // TODO: Add tests
+  expect(XiaoBoard).toBeDefined()
+})
+
+test("board props are forwarded to board elements", () => {
+  const shieldBoard = ArduinoShield({
+    name: "ArduinoShield",
+    boardProps: { layers: 4, material: "fr1" },
+  }) as any
+
+  const raspberryBoard = RaspberryPiHatBoard({
+    name: "Hat",
+    boardProps: { layers: 4, material: "fr1" },
+  }) as any
+
+  const microModBoard = MicroModBoard({
+    name: "MicroMod",
+    boardProps: { layers: 4, material: "fr1" },
+  }) as any
+
+  const xiaoBoard = XiaoBoard({
+    name: "Xiao",
+    boardProps: { layers: 4, material: "fr1" },
+  }) as any
+
+  for (const element of [
+    shieldBoard,
+    raspberryBoard,
+    microModBoard,
+    xiaoBoard,
+  ]) {
+    expect(element.props.layers).toBe(4)
+    expect(element.props.material).toBe("fr1")
+  }
 })


### PR DESCRIPTION
## Summary
- allow all exported *Board components to accept `boardProps` and forward them to the `<board>` element
- forward chip props to the underlying `<chip>` and add coverage that board props reach the rendered board element

## Testing
- bunx tsc --noEmit
- bun test tests/test.test.tsx

------
https://chatgpt.com/codex/tasks/task_b_68e03d24cc50832eb2e7ed8d3841ffd5