### PR TITLE
Add board prop support to board components

### DIFF
--- a/lib/ArduinoShield/ArduinoShield.circuit.tsx
+++ b/lib/ArduinoShield/ArduinoShield.circuit.tsx
@@ -1,112 +1,131 @@
-import type { ChipProps } from "@tscircuit/props"
+import type { BoardProps, ChipProps } from "@tscircuit/props"
 import { ArduinoShieldFootprint } from "./ArduinoShieldFootprint"
+import { splitBoardAndChipProps } from "../../util/splitBoardAndChipProps"
 
-export const ArduinoShield = (props: ChipProps & { children?: any }) => (
-  <board
-    outline={[
-      { x: -34.29, y: 26.67 }, // top-left corner
-      { x: 32.29, y: 26.67 }, // top-right (sharp)
-      { x: 34.29, y: 24.67 }, // top-right (sharp)
-      { x: 34.29, y: 13.89 }, // start top slanted transition
-      { x: 36.83, y: 11.35 }, // outward notch top
-      { x: 36.83, y: -21.35 }, // outward notch bottom
-      { x: 34.29, y: -23.89 }, // end bottom slanted transition
-      { x: 34.29, y: -26.67 }, // bottom-right corner
-      { x: -34.29, y: -26.67 }, // bottom-left corner
-    ]}
-  >
-    <group>
-      <chip
-        name={props.name}
-        pinLabels={{
-          pin1: "A0",
-          pin2: "A1",
-          pin3: "A2",
-          pin4: "A3",
-          pin5: "A4",
-          pin6: "A5",
-          pin7: "VIN",
-          pin8: "NC",
-          pin9: "IOREF",
-          pin10: "RES",
-          pin11: "V3_3",
-          pin12: "V5",
-          pin13: "GND0",
-          pin14: "GND1",
-          pin15: "RX",
-          pin16: "TX",
-          pin17: "D2",
-          pin18: "D3",
-          pin19: "D4",
-          pin20: "D5",
-          pin21: "D6",
-          pin22: "D7",
-          pin23: "D8",
-          pin24: "D9",
-          pin25: "D10",
-          pin26: "D11",
-          pin27: "D12",
-          pin28: "D13",
-          pin29: "GND2",
-          pin30: "AREF",
-          pin31: "SDA",
-          pin32: "SCL",
-        }}
-        schWidth={1.5}
-        schPinArrangement={{
-          leftSide: {
-            direction: "top-to-bottom",
-            pins: [
-              "A0",
-              "A1",
-              "A2",
-              "A3",
-              "A4",
-              "A5",
-              "IOREF",
-              "RES",
-              "VIN",
-              "V5",
-              "V3_3",
-              "AREF",
-              "GND0",
-              "GND1",
-              "GND2",
-            ],
-          },
-          rightSide: {
-            direction: "top-to-bottom",
-            pins: [
-              "RX",
-              "TX",
-              "D2",
-              "D3",
-              "D4",
-              "D5",
-              "D6",
-              "D7",
-              "D8",
-              "D9",
-              "D10",
-              "D11",
-              "D12",
-              "D13",
-              "SDA",
-              "SCL",
-            ],
-          },
-        }}
-        schPinStyle={{
-          pin6: {
-            marginBottom: 0.5,
-          },
-          pin16: {
-            marginBottom: 0.3,
-          },
-        }}
-        footprint={<ArduinoShieldFootprint />}
-      />
-      {props.children}
-    </group>
-  </board>
-)
+type ArduinoShieldProps = ChipProps &
+  BoardProps & { children?: any; boardName?: string }
+
+export const ArduinoShield = ({
+  boardName,
+  children,
+  ...rest
+}: ArduinoShieldProps) => {
+  const { boardProps, chipProps } = splitBoardAndChipProps({
+    ...rest,
+    boardName,
+  })
+
+  const { name, ...chipRest } = chipProps as ChipProps
+
+  return (
+    <board
+      {...boardProps}
+      outline={[
+        { x: -34.29, y: 26.67 }, // top-left corner
+        { x: 32.29, y: 26.67 }, // top-right (sharp)
+        { x: 34.29, y: 24.67 }, // top-right (sharp)
+        { x: 34.29, y: 13.89 }, // start top slanted transition
+        { x: 36.83, y: 11.35 }, // outward notch top
+        { x: 36.83, y: -21.35 }, // outward notch bottom
+        { x: 34.29, y: -23.89 }, // end bottom slanted transition
+        { x: 34.29, y: -26.67 }, // bottom-right corner
+        { x: -34.29, y: -26.67 }, // bottom-left corner
+      ]}
+    >
+      <group>
+        <chip
+          {...chipRest}
+          name={name}
+          pinLabels={{
+            pin1: "A0",
+            pin2: "A1",
+            pin3: "A2",
+            pin4: "A3",
+            pin5: "A4",
+            pin6: "A5",
+            pin7: "VIN",
+            pin8: "NC",
+            pin9: "IOREF",
+            pin10: "RES",
+            pin11: "V3_3",
+            pin12: "V5",
+            pin13: "GND0",
+            pin14: "GND1",
+            pin15: "RX",
+            pin16: "TX",
+            pin17: "D2",
+            pin18: "D3",
+            pin19: "D4",
+            pin20: "D5",
+            pin21: "D6",
+            pin22: "D7",
+            pin23: "D8",
+            pin24: "D9",
+            pin25: "D10",
+            pin26: "D11",
+            pin27: "D12",
+            pin28: "D13",
+            pin29: "GND2",
+            pin30: "AREF",
+            pin31: "SDA",
+            pin32: "SCL",
+          }}
+          schWidth={1.5}
+          schPinArrangement={{
+            leftSide: {
+              direction: "top-to-bottom",
+              pins: [
+                "A0",
+                "A1",
+                "A2",
+                "A3",
+                "A4",
+                "A5",
+                "IOREF",
+                "RES",
+                "VIN",
+                "V5",
+                "V3_3",
+                "AREF",
+                "GND0",
+                "GND1",
+                "GND2",
+              ],
+            },
+            rightSide: {
+              direction: "top-to-bottom",
+              pins: [
+                "RX",
+                "TX",
+                "D2",
+                "D3",
+                "D4",
+                "D5",
+                "D6",
+                "D7",
+                "D8",
+                "D9",
+                "D10",
+                "D11",
+                "D12",
+                "D13",
+                "SDA",
+                "SCL",
+              ],
+            },
+          }}
+          schPinStyle={{
+            pin6: {
+              marginBottom: 0.5,
+            },
+            pin16: {
+              marginBottom: 0.3,
+            },
+          }}
+          footprint={<ArduinoShieldFootprint />}
+        />
+        {children}
+      </group>
+    </board>
+  )
+}

--- a/lib/MicroModBoard/MicroModBoard.tsx
+++ b/lib/MicroModBoard/MicroModBoard.tsx
@@ -1,11 +1,28 @@
-import type { ChipProps } from "@tscircuit/props"
+import type { BoardProps, ChipProps } from "@tscircuit/props"
 import { MicroModBoardFootprint } from "./MicroModBoardFootprint"
 import { processorOutline, functionOutline } from "./outlines/boardOutlines"
+import { splitBoardAndChipProps } from "../../util/splitBoardAndChipProps"
+
+type MicroModBoardProps = ChipProps &
+  BoardProps & {
+    children?: any
+    variant?: "processor" | "function"
+    boardName?: string
+  }
 
 export const MicroModBoard = ({
   variant = "processor",
-  ...props
-}: ChipProps & { children?: any; variant?: "processor" | "function" }) => {
+  boardName,
+  children,
+  ...rest
+}: MicroModBoardProps) => {
+  const { boardProps, chipProps } = splitBoardAndChipProps({
+    ...rest,
+    boardName,
+  })
+
+  const { name, ...chipRest } = chipProps as ChipProps
+
   let outline
   const pinLabels = {
     pin2: ["V3_3_1"],
@@ -82,10 +99,11 @@ export const MicroModBoard = ({
   outline = variant === "processor" ? processorOutline : functionOutline
 
   return (
-    <board outline={outline}>
+    <board {...boardProps} outline={outline}>
       <group>
         <chip
-          name={props.name}
+          {...chipRest}
+          name={name}
           footprint={<MicroModBoardFootprint variant={variant} />}
           schWidth={2.8}
           pinLabels={pinLabels}
@@ -216,7 +234,7 @@ export const MicroModBoard = ({
             },
           }}
         />
-        {props.children}
+        {children}
       </group>
     </board>
   )

--- a/lib/RaspberryPiHatBoard/RaspberryPiHatBoard.circuit.tsx
+++ b/lib/RaspberryPiHatBoard/RaspberryPiHatBoard.circuit.tsx
@@ -1,7 +1,23 @@
-import type { ChipProps } from "@tscircuit/props"
+import type { BoardProps, ChipProps } from "@tscircuit/props"
 import { OutlineBuilder } from "../../util/outlineBuilder"
+import { splitBoardAndChipProps } from "../../util/splitBoardAndChipProps"
 
-export const RaspberryPiHatBoard = (props: ChipProps & { children?: any }) => {
+type RaspberryPiHatBoardProps = ChipProps &
+  BoardProps & { children?: any; boardName?: string }
+
+export const RaspberryPiHatBoard = ({
+  boardName,
+  children,
+  ...rest
+}: RaspberryPiHatBoardProps) => {
+  const { boardProps, chipProps } = splitBoardAndChipProps({
+    ...rest,
+    boardName,
+  })
+
+  const { name, ...chipRest } = chipProps as ChipProps
+  const resolvedChipName = name ?? "JP1"
+
   const outline = new OutlineBuilder(0, 28)
     .lineTo(32.5, 28)
     .corner({ radius: 1, turn: "ccw" })
@@ -71,10 +87,11 @@ export const RaspberryPiHatBoard = (props: ChipProps & { children?: any }) => {
   }
 
   return (
-    <board outline={outline}>
+    <board {...boardProps} outline={outline}>
       <group>
         <chip
-          name="JP1"
+          {...chipRest}
+          name={resolvedChipName}
           schWidth={3.5}
           pinLabels={pinLabels}
           layer="bottom"
@@ -167,7 +184,7 @@ export const RaspberryPiHatBoard = (props: ChipProps & { children?: any }) => {
         <hole diameter={2.8} pcbX={29} pcbY={-24.5} />
         <hole diameter={2.8} pcbX={-29} pcbY={-24.5} />
         <hole diameter={2.8} pcbX={29} pcbY={24.5} />
-        {props.children}
+        {children}
       </group>
     </board>
   )

--- a/lib/XiaoBoard/XiaoBoard.circuit.tsx
+++ b/lib/XiaoBoard/XiaoBoard.circuit.tsx
@@ -1,18 +1,29 @@
-import type { ChipProps } from "@tscircuit/props"
+import type { BoardProps, ChipProps } from "@tscircuit/props"
 import { XiaoBoardFootprint } from "./XiaoBoardFootprint"
 import { outlineBuilder } from "../../util/outlineBuilder"
+import { splitBoardAndChipProps } from "../../util/splitBoardAndChipProps"
 
-interface XiaoBoardProps extends ChipProps {
+type XiaoBoardProps = (ChipProps & BoardProps) & {
   children?: any
   variant?: "RP2040" | "Receiver"
   withPlatedHoles?: boolean
+  boardName?: string
 }
 
 export const XiaoBoard = ({
   variant,
   withPlatedHoles = false,
-  ...props
+  boardName,
+  children,
+  ...rest
 }: XiaoBoardProps) => {
+  const { boardProps, chipProps } = splitBoardAndChipProps({
+    ...rest,
+    boardName,
+  })
+
+  const { name, ...chipRest } = chipProps as ChipProps
+
   const DefaultPinLabels = {
     pin1: "A0",
     pin2: "A1",
@@ -98,10 +109,11 @@ export const XiaoBoard = ({
     .toArray()
 
   return (
-    <board outline={outline}>
+    <board {...boardProps} outline={outline}>
       <group>
         <chip
-          name={props.name}
+          {...chipRest}
+          name={name}
           footprint={
             <XiaoBoardFootprint
               variant={variant}
@@ -133,7 +145,7 @@ export const XiaoBoard = ({
             },
           })}
         />
-        {props.children}
+        {children}
       </group>
     </board>
   )

--- a/tests/splitBoardAndChipProps.test.ts
+++ b/tests/splitBoardAndChipProps.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test"
+import type { BoardProps, ChipProps } from "@tscircuit/props"
+import { splitBoardAndChipProps } from "../util/splitBoardAndChipProps"
+
+describe("splitBoardAndChipProps", () => {
+  test("separates board-specific props while preserving chip props", () => {
+    const props = {
+      name: "U1",
+      autorouter: "auto" as BoardProps["autorouter"],
+      material: "fr4" as BoardProps["material"],
+      pcbX: "10mm" as ChipProps["pcbX"],
+      boardName: "BoardRef",
+      schWidth: 2 as BoardProps["schWidth"],
+    }
+
+    const { boardProps, chipProps } = splitBoardAndChipProps(props)
+
+    expect(boardProps.autorouter).toBe("auto")
+    expect(boardProps.material).toBe("fr4")
+    expect(boardProps.name).toBe("BoardRef")
+    expect(boardProps.pcbX).toBe("10mm")
+    expect(boardProps.schWidth).toBe(2)
+
+    expect(chipProps.name).toBe("U1")
+    expect("autorouter" in chipProps).toBe(false)
+    expect(chipProps.pcbX).toBe("10mm")
+  })
+})

--- a/util/splitBoardAndChipProps.ts
+++ b/util/splitBoardAndChipProps.ts
@@ -1,0 +1,34 @@
+import type { BoardProps, ChipProps } from "@tscircuit/props"
+import {
+  boardProps as boardPropsSchema,
+  chipProps as chipPropsSchema,
+} from "@tscircuit/props"
+
+type CombinedProps = Partial<BoardProps & ChipProps> & { boardName?: string }
+
+const boardPropKeys = new Set<string>(
+  Array.from(boardPropsSchema.keyof().options),
+)
+const chipPropKeys = new Set<string>(
+  Array.from(chipPropsSchema.keyof().options),
+)
+
+export const splitBoardAndChipProps = (props: CombinedProps) => {
+  const { boardName, ...rest } = props
+
+  const boardProps = Object.fromEntries(
+    Object.entries(rest).filter(([key]) => boardPropKeys.has(key)),
+  ) as Partial<BoardProps>
+
+  const chipProps = Object.fromEntries(
+    Object.entries(rest).filter(([key]) => chipPropKeys.has(key)),
+  ) as Partial<ChipProps>
+
+  if (boardName !== undefined) {
+    boardProps.name = boardName
+  } else if (chipProps.name !== undefined && boardProps.name === undefined) {
+    boardProps.name = chipProps.name
+  }
+
+  return { boardProps, chipProps }
+}


### PR DESCRIPTION
## Summary
- add a shared helper for splitting chip and board props so board props can be forwarded
- update exported board components to accept board props and optional board names
- cover the prop splitter with a unit test

## Testing
- bunx tsc --noEmit
- bun test

------
https://chatgpt.com/codex/tasks/task_b_68e0443b9a58832e92f5322b116ea14a