### PR TITLE
Fix MicroMod board names to avoid tsci build duplication

### DIFF
--- a/lib/MicroModBoard/MicroModBoardFunction.circuit.tsx
+++ b/lib/MicroModBoard/MicroModBoardFunction.circuit.tsx
@@ -1,4 +1,9 @@
 import { MicroModBoard } from "./MicroModBoard"
+
 export default () => (
-  <MicroModBoard name="MicroModBoardFunction" variant="function" />
+  <MicroModBoard
+    name="MicroModBoardFunction"
+    boardName="MicroModBoardFunctionBoard"
+    variant="function"
+  />
 )

--- a/lib/MicroModBoard/MicroModBoardProcessor.circuit.tsx
+++ b/lib/MicroModBoard/MicroModBoardProcessor.circuit.tsx
@@ -1,4 +1,9 @@
 import { MicroModBoard } from "./MicroModBoard"
+
 export default () => (
-  <MicroModBoard name="MicroModBoardProcessor" variant="processor" />
+  <MicroModBoard
+    name="MicroModBoardProcessor"
+    boardName="MicroModBoardProcessorBoard"
+    variant="processor"
+  />
 )


### PR DESCRIPTION
## Summary
- set explicit board names for the MicroMod board variants so their chip and board components no longer collide during `tsci build`

## Testing
- bun run build:circuit
- bunx tsc --noEmit


------
https://chatgpt.com/codex/tasks/task_b_68e06bee9388832ea796ce8327008494