### PR TITLE
Update chip name to include '_chip' suffix to stop "A component with the same name already exists" Error

### DIFF
--- a/lib/MicroModBoard/MicroModBoard.tsx
+++ b/lib/MicroModBoard/MicroModBoard.tsx
@@ -103,7 +103,7 @@ export const MicroModBoard = ({
       <group>
         <chip
           {...chipRest}
-          name={name}
+          name={`${name}_chip`}
           footprint={<MicroModBoardFootprint variant={variant} />}
           schWidth={2.8}
           pinLabels={pinLabels}


### PR DESCRIPTION
Fix error:
```
source_failed_to_create_component_error: Cannot create component "micromod": A component with the same name already exists
@tscircuit/eval@0.0.369
@tscircuit/core@0.0.768
```