### PR TITLE
Fix audio VREF decoupling trace length

### DIFF
--- a/lib/AudioAmplifier3W_PAM8403/AudioAmplifier3W_PAM8403.circuit.tsx
+++ b/lib/AudioAmplifier3W_PAM8403/AudioAmplifier3W_PAM8403.circuit.tsx
@@ -328,12 +328,14 @@ export const AudioAmplifier3W_PAM8403 = ({
     <trace
       from=".U_SPK_AMP > .VREF"
       to=".C_AMP_VREF > .pin1"
+      maxLength="5.5mm"
       {...signalTraceProps}
       schDisplayLabel="VREF"
     />
     <trace
       from=".C_AMP_VREF > .pin2"
       to="net.GND"
+      maxLength="5.5mm"
       {...signalTraceProps}
       {...gndLabel}
     />

--- a/tests/test.test.tsx
+++ b/tests/test.test.tsx
@@ -139,6 +139,28 @@ test("AudioAmplifier3W_PAM8403 renders the complete mono audio path", async () =
   expect(circuit.db.source_net.getWhere({ name: "VSYS" })).toBeDefined()
   expect(circuit.db.source_net.getWhere({ name: "GND" })).toBeDefined()
   expectNetsExposed(circuit, ["AUDIO_PWM", "V3V3", "VSYS", "GND"])
+  const vrefCapacitor = circuit.db.source_component.getWhere({
+    name: "C_AMP_VREF",
+  })
+  const vrefCapacitorPortIds = new Set(
+    circuit.db.source_port
+      .list()
+      .filter(
+        (port) =>
+          port.source_component_id === vrefCapacitor?.source_component_id,
+      )
+      .map((port) => port.source_port_id),
+  )
+  expect(
+    circuit.db.source_trace
+      .list()
+      .filter((trace) =>
+        trace.connected_source_port_ids.some((portId) =>
+          vrefCapacitorPortIds.has(portId),
+        ),
+      )
+      .map((trace) => trace.max_length),
+  ).toEqual([5.5, 5.5])
   expect(
     circuitJson.filter((element) => element.type.endsWith("_error")),
   ).toEqual([])


### PR DESCRIPTION
## What changed

- Keep the existing explicit VREF capacitor `<trace>` elements.
- Set `maxLength="5.5mm"` on both VREF capacitor traces.
- Add regression coverage confirming both generated source-trace limits are 5.5 mm.

## Why

The traces inherited the capacitor’s default 1 mm decoupling limit while the placed endpoints are about 5.14 mm apart. That made the constraint impossible and caused autorouting to skip the audio subcircuit. An explicit 5.5 mm limit preserves the existing trace-based circuit structure and makes the layout routable.

## Validation

- `bun test` — 17 passed, 0 failed
- `bun run build:lib`
- Biome format check
- PCB and schematic snapshots match
- Audio autoroute — 26 traces, 0 jumpers, 0 errors