### PR TITLE
Migrate npm publishing to OIDC

### DIFF
--- a/.github/workflows/bun-pver-release.yml
+++ b/.github/workflows/bun-pver-release.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - main
+
+permissions:
+  contents: write
+  id-token: write
+  pull-requests: write
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -15,14 +21,14 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org/
+          package-manager-cache: false
       - run: npm install -g pver
       - run: bun install --frozen-lockfile
       - run: bun run build
       - run: pver release
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.TSCIRCUIT_BOT_GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@tscircuit/common",
   "version": "0.0.59",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tscircuit/common.git"
+  },
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
## Summary

- grant GitHub Actions OIDC permission for npm trusted publishing
- remove the legacy npm token from the release step
- use Node 24 with actions/setup-node v6
- add explicit repository metadata where missing

## Validation

- parsed the release workflow as YAML
- parsed package.json
- ran git diff --check
- confirmed the release workflow no longer references NPM_TOKEN
